### PR TITLE
Expose more MapDB options

### DIFF
--- a/test/spicerack/core_test.clj
+++ b/test/spicerack/core_test.clj
@@ -59,4 +59,11 @@
     ;; test-db file is really there to delete
     (is (= true (cleanup)))))
 
+(deftest database-options
+  (testing "By default read-only? is false"
+    (with-open [db (open-database test-filename)]
+      (is (not (.isReadOnly (.getStore db))))))
 
+  (testing "Setting read-only? to true"
+    (with-open [db (open-database test-filename :read-only? true)]
+      (is (.isReadOnly (.getStore db))))))


### PR DESCRIPTION
Make some underlying options available through open-database:

- transactionEnable
- checksumHeaderBypass

Make fileMmapEnable configurable.

Use fileMmapEnableIfSupported instead of fileMmapEnable, since the latter will
fail on 32-bit JVMs.

I only found out how to inspect the read-only flag on a database, couldn't figure out how to test the other options.