### PR TITLE
Make update! accept extra function arguments

### DIFF
--- a/src/spicerack/core.clj
+++ b/src/spicerack/core.clj
@@ -133,8 +133,8 @@
 
 (defn update!
   "Calls function `f` with the current value associated with `k` in hashmap `m` as the parameter, then writes the result back to m. If k has not yet been set, it's previous value will be nil. Returns the value written."
-  [m k f]
-  (let [new-value (f (.get m k))]
+  [m k f & args]
+  (let [new-value (apply f (.get m k) args)]
     (.put m k new-value)
     new-value))
 

--- a/test/spicerack/core_test.clj
+++ b/test/spicerack/core_test.clj
@@ -50,7 +50,10 @@
           ;; how about a vector?
           (is (= test-vector (put! hm :test-vector test-vector)))
           ;; still there?
-          (is (= test-vector (get hm :test-vector)))))
+          (is (= test-vector (get hm :test-vector)))
+          ;; update! accepts partial function arguments
+          (is (= {} (put! hm :numbers {})))
+          (is (= {:x 5} (update! hm :numbers assoc :x 5)))))
       ;; now the db is closed, re-open it read-only and read
       (with-open [db (open-database test-filename :read-only? true)]
         (let [hm (open-hashmap db "test-hashmap" :read-only? true)]


### PR DESCRIPTION
Make update! behave more like update/update-in/swap!, in that extra arguments to
the passed in function can be specified directly.

Before:

    (put! hm :users [])
    (update! hm :users #(conj % {:name "plexus"})

After:

    (put! hm :users [])
    (update! hm :users conj {:name "plexus"})