### PR TITLE
Bump version in README to match project.clj (0.1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ deployed in production, and quite useful.
 ## Usage 
 
 ``` clojure
-[spicerack "0.1.4"]
+[spicerack "0.1.5"]
 ```
 
 There are only a handful of functions in this wrapper. It provides


### PR DESCRIPTION
Fixes omission in aa50a65d58812bfa5fb159c852f4f1bf36b8d925