### PR TITLE
Depend on specific version of Kotlin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,11 +8,15 @@
                  [org.eclipse.collections/eclipse-collections "7.1.1"]
                  [org.eclipse.collections/eclipse-collections-forkjoin "7.1.1"]
                  [com.google.guava/guava "19.0"]
+                 [org.jetbrains.kotlin/kotlin-stdlib "1.2.71"] ; see exclusion
                  [org.mapdb/mapdb "3.0.7"
-                  :exclusions  [org.eclipse.collections/eclipse-collections-api
+                  :exclusions [org.eclipse.collections/eclipse-collections-api
                                org.eclipse.collections/eclipse-collections
                                org.eclipse.collections/eclipse-collections-forkjoin
-                               com.google.guava/guava]]]
+                               com.google.guava/guava
+                               ;; Use specific Kotlin version (above)
+                               ;; instead of MapDB's version range:
+                               org.jetbrains.kotlin/kotlin-stdlib]]]
   :profiles {:codox {:dependencies [[codox-theme-rdash "0.1.2"]]
                      :plugins [[lein-codox "0.10.3"]]
                      :codox {:project {:name "spicerack"}
@@ -21,5 +25,3 @@
                              :output-path "gh-pages"}}}
   :aliases {"codox" ["with-profile" "codox,dev" "codox"]}
   :deploy-repositories [["releases" :clojars]])
-
-


### PR DESCRIPTION
This PR declares an explicit dependency on a specific Kotlin version, in order to prevent use of MapDB's version _range_ for that dependency. This eliminates the (small) possibility of hard-to-duplicate problems arising from non-deterministic builds, as well as eliminating Leiningen's version range warning, e.g.:

```shell
WARNING!!! version ranges found for:
[org.mapdb/mapdb "3.0.7" :exclusions [org.eclipse.collections/eclipse-collections-api org.eclipse.collections/eclipse-collections org.eclipse.collections/eclipse-collections-forkjoin com.google.guava/guava]] -> [org.jetbrains.kotlin/kotlin-stdlib "[1.2.41,1.2.90)"]
Consider using [org.mapdb/mapdb "3.0.7" :exclusions [org.eclipse.collections/eclipse-collections org.jetbrains.kotlin/kotlin-stdlib com.google.guava/guava org.eclipse.collections/eclipse-collections-forkjoin org.eclipse.collections/eclipse-collections-api]].
```